### PR TITLE
add docker host env to readme instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ docker run --detach \
   --publish 8000:8000 \
   --volumes-from swarm-data \
   --env TOKEN=$SECRET \
+  --env DOCKER_HOST=$DOCKER_HOST \
   --env DOCKER_CERT_PATH=/etc/docker/cert.pem \
   --env DOCKER_CA_CERT_PATH=/etc/docker/ca.pem \
   --env DOCKER_KEY_PATH=/etc/docker/key.pem \


### PR DESCRIPTION
When trying to get started with wiretap (using [this tutorial](https://getcarina.com/docs/tutorials/push-based-cd/)) I ran into a couple issues. Looking at this repo, I found the right solution in the README, however I also found that not supplying DOCKER_HOST as an environment variable results in issues whenever the endpoint is hit.